### PR TITLE
Feature: add kwargs for create_bot

### DIFF
--- a/nonebug/mixin/call_api/__init__.py
+++ b/nonebug/mixin/call_api/__init__.py
@@ -17,10 +17,15 @@ class ApiContext(Context):
         super().__init__(app, *args, **kwargs)
         self.wait_list: Queue[Model] = Queue()
 
-    def create_adapter(self, *, base: Optional[Type["Adapter"]] = None) -> "Adapter":
+    def create_adapter(
+        self,
+        *,
+        base: Optional[Type["Adapter"]] = None,
+        **kwargs: Any,
+    ) -> "Adapter":
         from nonebot import get_driver
 
-        return make_fake_adapter(base=base)(get_driver(), self)
+        return make_fake_adapter(base=base)(get_driver(), self, **kwargs)
 
     def create_bot(
         self,
@@ -28,11 +33,12 @@ class ApiContext(Context):
         base: Optional[Type["Bot"]] = None,
         adapter: Optional["Adapter"] = None,
         self_id: str = "test",
+        **kwargs: Any,
     ) -> "Bot":
         from nonebot import get_driver
 
         adapter = adapter or make_fake_adapter()(get_driver(), self)
-        return make_fake_bot(base=base)(adapter, self_id)
+        return make_fake_bot(base=base)(adapter, self_id, **kwargs)
 
     def mock_adapter(self, monkeypatch: pytest.MonkeyPatch, adapter: "Adapter") -> None:
         new_adapter = self.create_adapter()


### PR DESCRIPTION
由于 Onebot V12 的 Bot 初始化需要 `platform` 属性，在使用 `create_bot(base=V12Bot)` 的时候无法传入该属性

![Snipaste_2023-01-17_20-16-30](https://user-images.githubusercontent.com/33149974/212905891-f34eb6b2-2ff0-4094-afbb-8e89591b0761.png)
